### PR TITLE
Fix length byte in DIO RPL Prefix Info Option

### DIFF
--- a/lib/libndmgmt/dio.cpp
+++ b/lib/libndmgmt/dio.cpp
@@ -136,7 +136,7 @@ int dag_network::build_prefix_dioopt(ip_subnet prefix)
         diodp->rpl_dio_prefix[i]=prefix.addr.u.v6.sin6_addr.s6_addr[i];
     }
 
-    this->optlen = 30;
+    this->optlen = 32;
 
     return this->optlen;
 }


### PR DESCRIPTION
This updates DIO messages to have the correct length in the Prefix Information option. The outgoing packet should have the length set to 30 (https://tools.ietf.org/html/rfc6550#section-6.7.10), but it was getting set to 28.

I'm not sure if this is the best way to fix it, as the `-2` in line 123 of the same file may be what was making it 28 instead of 30. But in testing this patch does achieve the correct outcome.