### PR TITLE
Update main loop to new queue API

### DIFF
--- a/lib/libndmgmt/iface.cpp
+++ b/lib/libndmgmt/iface.cpp
@@ -995,10 +995,11 @@ void network_interface::main_loop(FILE *verbose, rpl_debug *debug)
 	debug->verbose2("checking things to do list, has %d items\n",
 			things_to_do.size());
 
-        rpl_event *re = things_to_do.peek_event();
-        while((re = things_to_do.peek_event()) != NULL) {
+        rpl_event *re = NULL;
+        while(things_to_do.size() > 0 && (re = things_to_do.peek_event()) != NULL) {
             if(re->passed(now)) {
 		things_to_do.eat_event();
+                re->inQueue = false;
                 if(re->doit()) {
                     re->requeue(things_to_do, now);
                 } else {


### PR DESCRIPTION
Calling `peek_event()` when the `things_to_do` queue is empty
trips a Boost assertion. This update checks to make sure there is
something in the queue before calling `peek_event()`.

Also, `eat_event()` calls `pop()` on the queue, which removes the item
from the queue. However, it doesn't update the internal state of the
item, in particular it doesn't un-mark the item as in a queue. Later on,
this causes the `reenqueue()` function to not re-add the item to the
queue, causing the event to never get triggered again. To fix this, we
update the state of the event after calling `eat_event()`.